### PR TITLE
Scripts: Added Kraken and Porter sys id's

### DIFF
--- a/script/2018/Kraken.Ground/StartGround.scr
+++ b/script/2018/Kraken.Ground/StartGround.scr
@@ -17,3 +17,9 @@ layout load
 
 # throw away sysid2 pkts
 output sysid 2 127.0.0.1:9991
+
+set source_system 253
+
+module load cuav.modules.cuav_check
+
+module load map

--- a/script/2018/Kraken.Ground/StartGround.sh
+++ b/script/2018/Kraken.Ground/StartGround.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
 #All telemetry from the Rpi on the Porter over two networks
-mavproxy.py --aircraft Kraken --master=:14650 --force-connected --mav20 --console --map --cmd="script StartGround.scr" $*
+mavproxy.py --aircraft Kraken --master=:14650 --force-connected --mav20 --console --map --force-connect --cmd="script StartGround.scr" $*
 

--- a/script/2018/Porter.GroundBackup/StartGround.scr
+++ b/script/2018/Porter.GroundBackup/StartGround.scr
@@ -31,3 +31,5 @@ map3 follow 0
 map3 zoom 50
 
 
+module load cuav.modules.cuav_check
+

--- a/script/2018/Porter.GroundBackup/StartGround.sh
+++ b/script/2018/Porter.GroundBackup/StartGround.sh
@@ -7,5 +7,5 @@
 PORT=$(/bin/ls /dev/serial/by-id/usb-FTDI*)
 
 #All telemetry from the RFD900 or Tridge's laptop
-mavproxy.py --aircraft Porter --master $PORT --master :14660 --mav20 --console --map --cmd="script StartGround.scr" $*
+mavproxy.py --aircraft Porter --master $PORT --master :14660 --mav20 --console --map --force-connect --cmd="script StartGround.scr" $*
 


### PR DESCRIPTION
For my GCS - added sys-id enforcing, cuav_check module and the ``--force-connected``