### PR TITLE
Scripts - added scripts for viewing Kraken and Porter on big screen

### DIFF
--- a/script/2018/Kraken.Ground/BigScreenKraken.sh
+++ b/script/2018/Kraken.Ground/BigScreenKraken.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+#This is for visualisation of the Kraken on the big screen
+#on Stephen's laptop. Just a console and map
+
+#Can't use the default modules list - the layout module messes us
+#up here with restoring the windows to the same position as for the
+#other UAV
+
+#Packets come from the Kraken.Ground
+mavproxy.py --aircraft KrakenScreen --master=udp:127.0.0.1:16001 --mav20 --force-connected --console --map $*

--- a/script/2018/Kraken.Ground/BigScreenPorter.sh
+++ b/script/2018/Kraken.Ground/BigScreenPorter.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+#This is for visualisation of the Porter on the big screen
+#on Stephen's laptop. Just a console and map
+
+#Can't use the default modules list - the layout module messes us
+#up here with restoring the windows to the same position as for the
+#other UAV
+
+#Packets come from the Porter.GroundBackup
+mavproxy.py --aircraft PorterScreen --master=udp:127.0.0.1:16000 --mav20 --force-connected --console --map $*

--- a/script/2018/Kraken.Ground/StartGround.scr
+++ b/script/2018/Kraken.Ground/StartGround.scr
@@ -18,3 +18,6 @@ layout load
 
 # throw away sysid2 pkts
 output sysid 2 127.0.0.1:9991
+
+#output to big screen
+output add udp:127.0.0.1:16001

--- a/script/2018/Porter.GroundBackup/StartGround.scr
+++ b/script/2018/Porter.GroundBackup/StartGround.scr
@@ -30,4 +30,5 @@ module load map
 map3 follow 0
 map3 zoom 50
 
-
+#output to big screen
+output add udp:127.0.0.1:16000


### PR DESCRIPTION
I've got 2x extra mavproxy scripts for running the map/console on the TV. For safety, they're seperate instances. Communicating with the operation GCS instances via udp ports 16000, 16001